### PR TITLE
Fix: `XCHAL_HAVE_ADDX` config is virtually ineffective against GCC 10.1 or later

### DIFF
--- a/patches/gcc10.1/gcc-repair-TARGET_ADDX.patch
+++ b/patches/gcc10.1/gcc-repair-TARGET_ADDX.patch
@@ -1,0 +1,63 @@
+diff --git a/gcc/config/xtensa/predicates.md b/gcc/config/xtensa/predicates.md
+index 5bf4b9f5..ffdc4cb2 100644
+--- a/gcc/config/xtensa/predicates.md
++++ b/gcc/config/xtensa/predicates.md
+@@ -29,6 +29,12 @@
+ 		    || INTVAL (op) == 4
+ 		    || INTVAL (op) == 8")))
+ 
++(define_predicate "addsubx_alt_operand"
++  (and (match_code "const_int")
++       (match_test "INTVAL (op) == 1
++		    || INTVAL (op) == 2
++		    || INTVAL (op) == 3")))
++
+ (define_predicate "arith_operand"
+   (ior (and (match_code "const_int")
+ 	    (match_test "xtensa_simm8 (INTVAL (op))"))
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index b95b9901..7d7970f9 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -170,6 +170,20 @@
+   [(set_attr "type"	"arith")
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3")])
++ 
++(define_insn "*addx_alt"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(plus:SI (ashift:SI (match_operand:SI 1 "register_operand" "r")
++			    (match_operand:SI 3 "addsubx_alt_operand" "i"))
++		 (match_operand:SI 2 "register_operand" "r")))]
++  "TARGET_ADDX"
++{
++  operands[3] = GEN_INT (1 << INTVAL (operands[3]));
++  return "addx%3\t%0, %1, %2";
++}
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"3")])
+ 
+ (define_insn "addsf3"
+   [(set (match_operand:SF 0 "register_operand" "=f")
+@@ -204,6 +218,20 @@
+   [(set_attr "type"	"arith")
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3")])
++
++(define_insn "*subx_alt"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(minus:SI (ashift:SI (match_operand:SI 1 "register_operand" "r")
++			     (match_operand:SI 3 "addsubx_alt_operand" "i"))
++		  (match_operand:SI 2 "register_operand" "r")))]
++  "TARGET_ADDX"
++{
++  operands[3] = GEN_INT (1 << INTVAL (operands[3]));
++  return "subx%3\t%0, %1, %2";
++}
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"3")])
+ 
+ (define_insn "subsf3"
+   [(set (match_operand:SF 0 "register_operand" "=f")

--- a/patches/gcc10.2/gcc-repair-TARGET_ADDX.patch
+++ b/patches/gcc10.2/gcc-repair-TARGET_ADDX.patch
@@ -1,0 +1,63 @@
+diff --git a/gcc/config/xtensa/predicates.md b/gcc/config/xtensa/predicates.md
+index 5bf4b9f5..ffdc4cb2 100644
+--- a/gcc/config/xtensa/predicates.md
++++ b/gcc/config/xtensa/predicates.md
+@@ -29,6 +29,12 @@
+ 		    || INTVAL (op) == 4
+ 		    || INTVAL (op) == 8")))
+ 
++(define_predicate "addsubx_alt_operand"
++  (and (match_code "const_int")
++       (match_test "INTVAL (op) == 1
++		    || INTVAL (op) == 2
++		    || INTVAL (op) == 3")))
++
+ (define_predicate "arith_operand"
+   (ior (and (match_code "const_int")
+ 	    (match_test "xtensa_simm8 (INTVAL (op))"))
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index b95b9901..7d7970f9 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -170,6 +170,20 @@
+   [(set_attr "type"	"arith")
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3")])
++ 
++(define_insn "*addx_alt"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(plus:SI (ashift:SI (match_operand:SI 1 "register_operand" "r")
++			    (match_operand:SI 3 "addsubx_alt_operand" "i"))
++		 (match_operand:SI 2 "register_operand" "r")))]
++  "TARGET_ADDX"
++{
++  operands[3] = GEN_INT (1 << INTVAL (operands[3]));
++  return "addx%3\t%0, %1, %2";
++}
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"3")])
+ 
+ (define_insn "addsf3"
+   [(set (match_operand:SF 0 "register_operand" "=f")
+@@ -204,6 +218,20 @@
+   [(set_attr "type"	"arith")
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3")])
++
++(define_insn "*subx_alt"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(minus:SI (ashift:SI (match_operand:SI 1 "register_operand" "r")
++			     (match_operand:SI 3 "addsubx_alt_operand" "i"))
++		  (match_operand:SI 2 "register_operand" "r")))]
++  "TARGET_ADDX"
++{
++  operands[3] = GEN_INT (1 << INTVAL (operands[3]));
++  return "subx%3\t%0, %1, %2";
++}
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"3")])
+ 
+ (define_insn "subsf3"
+   [(set (match_operand:SF 0 "register_operand" "=f")


### PR DESCRIPTION
See https://github.com/esp8266/Arduino/issues/7742