### PR TITLE
GCC: Try to avoid using L32R to load 32/64bit constant

### DIFF
--- a/patches/gcc10.1/gcc-try-to-avoid-using-L32R-to-load-32-64bit-const.patch
+++ b/patches/gcc10.1/gcc-try-to-avoid-using-L32R-to-load-32-64bit-const.patch
@@ -1,0 +1,55 @@
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 953f90a0..14be4081 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1072,6 +1072,21 @@
+ 
+       if (! TARGET_AUTO_LITPOOLS && ! TARGET_CONST16)
+ 	{
++	  /* Try to emit MOVI.N + SLLI sequence, that is smaller than L32R + constant pool.  */
++	  if (TARGET_DENSITY && mode == SImode && register_operand (dst, mode))
++	    {
++	      int srcval = INTVAL (src);
++	      int shift;
++	      if (! (srcval & 1))
++		for (srcval >>= 1, shift = 1; ! (srcval & 1) && shift < 32; srcval >>= 1, shift++)
++		  if (srcval >= -32 && srcval <= 95)
++		    {
++		      emit_move_insn (dst, GEN_INT (srcval));
++		      emit_insn (gen_ashlsi3_internal (dst, dst, GEN_INT (shift)));
++		      return 1;
++		    }
++	    }
++
+ 	  src = force_const_mem (SImode, src);
+ 	  operands[1] = src;
+ 	}
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index 8e304a6f..dbb36b11 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -721,8 +721,22 @@
+ 	(match_operand:DI 1 "general_operand" ""))]
+   ""
+ {
+-  if (CONSTANT_P (operands[1]) && !TARGET_CONST16)
+-    operands[1] = force_const_mem (DImode, operands[1]);
++  if (CONSTANT_P (operands[1]))
++    {
++      /* Split in halves if 64-bit Const-to-Reg moves
++         because of offering further optimization opportunities.  */
++      if (register_operand (operands[0], DImode))
++        {
++          rtx first, second;
++          split_double (operands[1], &first, &second);
++          emit_insn (gen_movsi (gen_lowpart (SImode, operands[0]), first));
++          emit_insn (gen_movsi (gen_highpart (SImode, operands[0]), second));
++          DONE;
++        }
++
++      if (!TARGET_CONST16)
++        operands[1] = force_const_mem (DImode, operands[1]);
++    }
+ 
+   if (!register_operand (operands[0], DImode)
+       && !register_operand (operands[1], DImode))

--- a/patches/gcc10.2/gcc-try-to-avoid-using-L32R-to-load-32-64bit-const.patch
+++ b/patches/gcc10.2/gcc-try-to-avoid-using-L32R-to-load-32-64bit-const.patch
@@ -1,0 +1,55 @@
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 953f90a0..14be4081 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1072,6 +1072,21 @@
+ 
+       if (! TARGET_AUTO_LITPOOLS && ! TARGET_CONST16)
+ 	{
++	  /* Try to emit MOVI.N + SLLI sequence, that is smaller than L32R + constant pool.  */
++	  if (TARGET_DENSITY && mode == SImode && register_operand (dst, mode))
++	    {
++	      int srcval = INTVAL (src);
++	      int shift;
++	      if (! (srcval & 1))
++		for (srcval >>= 1, shift = 1; ! (srcval & 1) && shift < 32; srcval >>= 1, shift++)
++		  if (srcval >= -32 && srcval <= 95)
++		    {
++		      emit_move_insn (dst, GEN_INT (srcval));
++		      emit_insn (gen_ashlsi3_internal (dst, dst, GEN_INT (shift)));
++		      return 1;
++		    }
++	    }
++
+ 	  src = force_const_mem (SImode, src);
+ 	  operands[1] = src;
+ 	}
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index 8e304a6f..dbb36b11 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -721,8 +721,22 @@
+ 	(match_operand:DI 1 "general_operand" ""))]
+   ""
+ {
+-  if (CONSTANT_P (operands[1]) && !TARGET_CONST16)
+-    operands[1] = force_const_mem (DImode, operands[1]);
++  if (CONSTANT_P (operands[1]))
++    {
++      /* Split in halves if 64-bit Const-to-Reg moves
++         because of offering further optimization opportunities.  */
++      if (register_operand (operands[0], DImode))
++        {
++          rtx first, second;
++          split_double (operands[1], &first, &second);
++          emit_insn (gen_movsi (gen_lowpart (SImode, operands[0]), first));
++          emit_insn (gen_movsi (gen_highpart (SImode, operands[0]), second));
++          DONE;
++        }
++
++      if (!TARGET_CONST16)
++        operands[1] = force_const_mem (DImode, operands[1]);
++    }
+ 
+   if (!register_operand (operands[0], DImode)
+       && !register_operand (operands[1], DImode))


### PR DESCRIPTION
- try to transform 32-bit constants to that if these can be represented by immediate value from `MOVI.N` (-32 ~ 95) and a few of left-shifts
- split in halves if 64-bit constant-to-register moves because of offering further optimization opportunities.

example:
```
/* MOVI.N + SLLI  */
unsigned int test_reverse_msb(unsigned int a) {
    return a ^ 0x80000000U;  /* -0x20 << 26 */
}

/* split 64-bit constant loading */
unsigned long long test_64bit_const_0(void) {
    return 0xFFFFFFFFFFFFFFFFULL;  /* lowpart: -1, highpart: -1 */
}
unsigned long long test_64bit_const_1(void) {
    return 0x5000000000AC0000ULL;  /* lowpart: 0x56 << 17,  highpart: 0x50 << 24 */
}
unsigned long long test_64bit_const_2(void) {
    return 0x7D9FD4312C64B4DAULL;  /* 2 pairs of `L32R` + dword const in litpool */
}
```

results:
```
[before]
	.file	"test.c"
	.text
	.literal_position
	.literal .LC0, -2147483648
	.align	4
	.global	test_reverse_msb
	.type	test_reverse_msb, @function
test_reverse_msb:
	l32r	a3, .LC0
	xor	a2, a2, a3
	ret.n
	.size	test_reverse_msb, .-test_reverse_msb
	.literal_position
	.literal .LC1, -1, -1
	.align	4
	.global	test_64bit_const_0
	.type	test_64bit_const_0, @function
test_64bit_const_0:
	l32r	a2, .LC1
	l32r	a3, .LC1+4
	ret.n
	.size	test_64bit_const_0, .-test_64bit_const_0
	.literal_position
	.literal .LC2, 11272192, 1342177280
	.align	4
	.global	test_64bit_const_1
	.type	test_64bit_const_1, @function
test_64bit_const_1:
	l32r	a2, .LC2
	l32r	a3, .LC2+4
	ret.n
	.size	test_64bit_const_1, .-test_64bit_const_1
	.literal_position
	.literal .LC3, 744797402, 2107626545
	.align	4
	.global	test_64bit_const_2
	.type	test_64bit_const_2, @function
test_64bit_const_2:
	l32r	a2, .LC3
	l32r	a3, .LC3+4
	ret.n
	.size	test_64bit_const_2, .-test_64bit_const_2
	.ident	"GCC: (GNU) 10.2.0"
```
```
[after]
	.file	"test.c"
	.text
	.literal_position
	.align	4
	.global	test_reverse_msb
	.type	test_reverse_msb, @function
test_reverse_msb:
	movi.n	a3, -0x20
	slli	a3, a3, 26
	xor	a2, a2, a3
	ret.n
	.size	test_reverse_msb, .-test_reverse_msb
	.literal_position
	.align	4
	.global	test_64bit_const_0
	.type	test_64bit_const_0, @function
test_64bit_const_0:
	movi.n	a3, -1
	mov.n	a2, a3
	ret.n
	.size	test_64bit_const_0, .-test_64bit_const_0
	.literal_position
	.align	4
	.global	test_64bit_const_1
	.type	test_64bit_const_1, @function
test_64bit_const_1:
	movi.n	a2, 0x56
	movi.n	a3, 0x50
	slli	a2, a2, 17
	slli	a3, a3, 24
	ret.n
	.size	test_64bit_const_1, .-test_64bit_const_1
	.literal_position
	.literal .LC0, 744797402
	.literal .LC1, 2107626545
	.align	4
	.global	test_64bit_const_2
	.type	test_64bit_const_2, @function
test_64bit_const_2:
	l32r	a2, .LC0
	l32r	a3, .LC1
	ret.n
	.size	test_64bit_const_2, .-test_64bit_const_2
	.ident	"GCC: (GNU) 10.2.0"
```