### PR TITLE
GCC: Improve shift operations

### DIFF
--- a/patches/gcc10.1/gcc-improve-shift-operations.patch
+++ b/patches/gcc10.1/gcc-improve-shift-operations.patch
@@ -1,0 +1,75 @@
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index 21d60ffa..e82c466d 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -1050,6 +1050,16 @@
+   operands[1] = xtensa_copy_incoming_a7 (operands[1]);
+ })
+ 
++(define_insn "*ashlsi3_1"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashift:SI (match_operand:SI 1 "register_operand" "r")
++		   (const_int 1)))]
++  "TARGET_DENSITY"
++  "add.n\t%0, %1, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"2")])
++
+ (define_insn "ashlsi3_internal"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(ashift:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1062,6 +1072,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*ashlsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashift:SI (match_operand:SI 1 "register_operand" "r")
++		   (ashift:SI (match_operand:SI 2 "register_operand" "r")
++			      (const_int 3))))]
++  ""
++  "ssa8b\t%2\;sll\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "ashrsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(ashiftrt:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1074,6 +1095,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*ashrsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashiftrt:SI (match_operand:SI 1 "register_operand" "r")
++		     (ashift:SI (match_operand:SI 2 "register_operand" "r")
++				(const_int 3))))]
++  ""
++  "ssa8l\t%2\;sra\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "lshrsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(lshiftrt:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1093,6 +1125,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*lshrsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(lshiftrt:SI (match_operand:SI 1 "register_operand" "r")
++		     (ashift:SI (match_operand:SI 2 "register_operand" "r")
++				(const_int 3))))]
++  ""
++  "ssa8l\t%2\;srl\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "rotlsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(rotate:SI (match_operand:SI 1 "register_operand" "r,r")

--- a/patches/gcc10.2/gcc-improve-shift-operations.patch
+++ b/patches/gcc10.2/gcc-improve-shift-operations.patch
@@ -1,0 +1,75 @@
+diff --git a/gcc/config/xtensa/xtensa.md b/gcc/config/xtensa/xtensa.md
+index 21d60ffa..e82c466d 100644
+--- a/gcc/config/xtensa/xtensa.md
++++ b/gcc/config/xtensa/xtensa.md
+@@ -1050,6 +1050,16 @@
+   operands[1] = xtensa_copy_incoming_a7 (operands[1]);
+ })
+ 
++(define_insn "*ashlsi3_1"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashift:SI (match_operand:SI 1 "register_operand" "r")
++		   (const_int 1)))]
++  "TARGET_DENSITY"
++  "add.n\t%0, %1, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"2")])
++
+ (define_insn "ashlsi3_internal"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(ashift:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1062,6 +1072,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*ashlsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashift:SI (match_operand:SI 1 "register_operand" "r")
++		   (ashift:SI (match_operand:SI 2 "register_operand" "r")
++			      (const_int 3))))]
++  ""
++  "ssa8b\t%2\;sll\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "ashrsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(ashiftrt:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1074,6 +1095,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*ashrsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(ashiftrt:SI (match_operand:SI 1 "register_operand" "r")
++		     (ashift:SI (match_operand:SI 2 "register_operand" "r")
++				(const_int 3))))]
++  ""
++  "ssa8l\t%2\;sra\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "lshrsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(lshiftrt:SI (match_operand:SI 1 "register_operand" "r,r")
+@@ -1093,6 +1125,17 @@
+    (set_attr "mode"	"SI")
+    (set_attr "length"	"3,6")])
+ 
++(define_insn "*lshrsi3_3x"
++  [(set (match_operand:SI 0 "register_operand" "=a")
++	(lshiftrt:SI (match_operand:SI 1 "register_operand" "r")
++		     (ashift:SI (match_operand:SI 2 "register_operand" "r")
++				(const_int 3))))]
++  ""
++  "ssa8l\t%2\;srl\t%0, %1"
++  [(set_attr "type"	"arith")
++   (set_attr "mode"	"SI")
++   (set_attr "length"	"6")])
++
+ (define_insn "rotlsi3"
+   [(set (match_operand:SI 0 "register_operand" "=a,a")
+ 	(rotate:SI (match_operand:SI 1 "register_operand" "r,r")


### PR DESCRIPTION
- replace "left shift by 1" with "narrow add itself" when the Code Density Option is enabled
- add per-byte shift operations using SSA8[BL]