### PR TITLE
Makefile: instruct GCC to perform more aggressive optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,9 @@ INSTALLBRANCH ?= master
 
 # Environment variables for configure and building targets.  Only use $(call setenv,$@)
 ifeq ($(LTO),true)
-    CFFT := "-mlongcalls -flto -Wl,-flto -Os -g"
+    CFFT := "-mlongcalls -flto -Wl,-flto -Os -g -free -fipa-pta"
 else ifeq ($(LTO),false)
-    CFFT := "-mlongcalls -Os -g"
+    CFFT := "-mlongcalls -Os -g -free -fipa-pta"
 else
     $(error Need to specify LTO={true,false} on the command line)
 endif


### PR DESCRIPTION
* add `-free -fipa-pta` to GCC options (generates a bit smaller binary)

see https://github.com/arendst/Tasmota/pull/9749 and https://github.com/arendst/Tasmota/commit/e7cff928eef1f875819430f98e2b896b16b05b9b.