### PR TITLE
Build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,10 @@ clean: .cleaninst.LINUX.clean .cleaninst.LINUX32.clean .cleaninst.WIN32.clean .c
 	        gz)  (cd $(REPODIR)/$(GCC_DIR); tar xfz ../$${archive});; \
 	        bz2) (cd $(REPODIR)/$(GCC_DIR); tar xfj ../$${archive});; \
 	    esac ; \
-	    (cd $(REPODIR)/$(GCC_DIR); rm -rf $${base}; ln -s $${name} $${base}) \
+	    (cd $(REPODIR)/$(GCC_DIR); rm -rf $${base}; ln -s $${name} $${base}) ; \
+	    case "$${base}" in \
+	        libelf)	(cd $(REPODIR)/$(GCC_DIR)/$${base}; rm configure; autoreconf -i);;\
+	    esac ; \
 	done >> $(call log,$@) 2>&1
 	touch $@
 

--- a/patches/bin-002-fortify-source.patch
+++ b/patches/bin-002-fortify-source.patch
@@ -1,0 +1,19 @@
+diff --git a/gdb/common/common-defs.h b/gdb/common/common-defs.h
+index 88b05ef723c..214bca1ee17 100644
+--- a/gdb/common/common-defs.h
++++ b/gdb/common/common-defs.h
+@@ -66,9 +66,13 @@
+    plus this seems like a reasonable safety measure.  The check for
+    optimization is required because _FORTIFY_SOURCE only works when
+    optimization is enabled.  If _FORTIFY_SOURCE is already defined,
+-   then we don't do anything.  */
++   then we don't do anything.  Also, on MinGW, fortify requires
++   linking to -lssp, and to avoid the hassle of checking for
++   that and linking to it statically, we just don't define
++   _FORTIFY_SOURCE there.  */
+ 
+-#if !defined _FORTIFY_SOURCE && defined __OPTIMIZE__ && __OPTIMIZE__ > 0
++#if (!defined _FORTIFY_SOURCE && defined __OPTIMIZE__ && __OPTIMIZE__ > 0 \
++     && !defined(__MINGW32__))
+ #define _FORTIFY_SOURCE 2
+ #endif


### PR DESCRIPTION
As mentioned in the https://github.com/earlephilhower/newlib-xtensa/issues/19#issuecomment-906051683
Solves the issue with building on current Debian 11 by
- regenerating libelf ./configure, otherwise it would incorrectly detect the current compiler command and fail the `checking whether the C compiler works...` step
- adding binutils patch ignoring \_FORTIFY\_SOURCE
(and per https://sourceware.org/git/?p=binutils-gdb.git;a=history;f=gdb/gdbsupport/common-defs.h, there are no further changes)