### PR TITLE
gcc: xtensa: make trying to replace 'l32r' with 'movi' + 'slli' regardless of optimizing for size or not, because 'l32r' is much slower than the latter on ESP8266

### DIFF
--- a/patches/gcc10.1/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
+++ b/patches/gcc10.1/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
@@ -1,0 +1,29 @@
+From f1568d0597ffd3027eebefc2cf31646ab5d5ca19 Mon Sep 17 00:00:00 2001
+From: Takayuki 'January June' Suwa <jjsuwa_sys3175@yahoo.co.jp>
+Date: Sun, 19 Dec 2021 22:44:03 +0900
+Subject: [PATCH] gcc: xtensa: make trying to replace 'l32r' with 'movi' +
+ 'slli' regardless of optimizing for size or not, because 'l32r' is much
+ slower than the latter on ESP8266
+
+---
+ gcc/config/xtensa/xtensa.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 37c6ac1fd..6cd9d5528 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1074,8 +1074,8 @@ xtensa_emit_move_sequence (rtx *operands, machine_mode mode)
+ 	{
+ 	  /* Try to emit MOVI + SLLI sequence, that is smaller
+ 	     than L32R + literal.  */
+-	  if (optimize_size && mode == SImode && CONST_INT_P (src)
+-	      && register_operand (dst, mode))
++	  if (optimize >= 1 && ! optimize_debug && mode == SImode
++	      && CONST_INT_P (src) && register_operand (dst, mode))
+ 	    {
+ 	      HOST_WIDE_INT srcval = INTVAL (src);
+ 	      int shift = ctz_hwi (srcval);
+-- 
+2.20.1
+

--- a/patches/gcc10.2/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
+++ b/patches/gcc10.2/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
@@ -1,0 +1,29 @@
+From f1568d0597ffd3027eebefc2cf31646ab5d5ca19 Mon Sep 17 00:00:00 2001
+From: Takayuki 'January June' Suwa <jjsuwa_sys3175@yahoo.co.jp>
+Date: Sun, 19 Dec 2021 22:44:03 +0900
+Subject: [PATCH] gcc: xtensa: make trying to replace 'l32r' with 'movi' +
+ 'slli' regardless of optimizing for size or not, because 'l32r' is much
+ slower than the latter on ESP8266
+
+---
+ gcc/config/xtensa/xtensa.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 37c6ac1fd..6cd9d5528 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1074,8 +1074,8 @@ xtensa_emit_move_sequence (rtx *operands, machine_mode mode)
+ 	{
+ 	  /* Try to emit MOVI + SLLI sequence, that is smaller
+ 	     than L32R + literal.  */
+-	  if (optimize_size && mode == SImode && CONST_INT_P (src)
+-	      && register_operand (dst, mode))
++	  if (optimize >= 1 && ! optimize_debug && mode == SImode
++	      && CONST_INT_P (src) && register_operand (dst, mode))
+ 	    {
+ 	      HOST_WIDE_INT srcval = INTVAL (src);
+ 	      int shift = ctz_hwi (srcval);
+-- 
+2.20.1
+

--- a/patches/gcc10.3/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
+++ b/patches/gcc10.3/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
@@ -1,0 +1,29 @@
+From f1568d0597ffd3027eebefc2cf31646ab5d5ca19 Mon Sep 17 00:00:00 2001
+From: Takayuki 'January June' Suwa <jjsuwa_sys3175@yahoo.co.jp>
+Date: Sun, 19 Dec 2021 22:44:03 +0900
+Subject: [PATCH] gcc: xtensa: make trying to replace 'l32r' with 'movi' +
+ 'slli' regardless of optimizing for size or not, because 'l32r' is much
+ slower than the latter on ESP8266
+
+---
+ gcc/config/xtensa/xtensa.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 37c6ac1fd..6cd9d5528 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1074,8 +1074,8 @@ xtensa_emit_move_sequence (rtx *operands, machine_mode mode)
+ 	{
+ 	  /* Try to emit MOVI + SLLI sequence, that is smaller
+ 	     than L32R + literal.  */
+-	  if (optimize_size && mode == SImode && CONST_INT_P (src)
+-	      && register_operand (dst, mode))
++	  if (optimize >= 1 && ! optimize_debug && mode == SImode
++	      && CONST_INT_P (src) && register_operand (dst, mode))
+ 	    {
+ 	      HOST_WIDE_INT srcval = INTVAL (src);
+ 	      int shift = ctz_hwi (srcval);
+-- 
+2.20.1
+

--- a/patches/gcc11.1/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
+++ b/patches/gcc11.1/gcc-xtensa-0006-make-trying-to-replace-l32r-with-movi-sll.patch
@@ -1,0 +1,29 @@
+From f1568d0597ffd3027eebefc2cf31646ab5d5ca19 Mon Sep 17 00:00:00 2001
+From: Takayuki 'January June' Suwa <jjsuwa_sys3175@yahoo.co.jp>
+Date: Sun, 19 Dec 2021 22:44:03 +0900
+Subject: [PATCH] gcc: xtensa: make trying to replace 'l32r' with 'movi' +
+ 'slli' regardless of optimizing for size or not, because 'l32r' is much
+ slower than the latter on ESP8266
+
+---
+ gcc/config/xtensa/xtensa.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gcc/config/xtensa/xtensa.c b/gcc/config/xtensa/xtensa.c
+index 37c6ac1fd..6cd9d5528 100644
+--- a/gcc/config/xtensa/xtensa.c
++++ b/gcc/config/xtensa/xtensa.c
+@@ -1074,8 +1074,8 @@ xtensa_emit_move_sequence (rtx *operands, machine_mode mode)
+ 	{
+ 	  /* Try to emit MOVI + SLLI sequence, that is smaller
+ 	     than L32R + literal.  */
+-	  if (optimize_size && mode == SImode && CONST_INT_P (src)
+-	      && register_operand (dst, mode))
++	  if (optimize >= 1 && ! optimize_debug && mode == SImode
++	      && CONST_INT_P (src) && register_operand (dst, mode))
+ 	    {
+ 	      HOST_WIDE_INT srcval = INTVAL (src);
+ 	      int shift = ctz_hwi (srcval);
+-- 
+2.20.1
+


### PR DESCRIPTION
```
** constant loading benchmark test **

** adjacent 3 loading, 100000 times **
MOVI instruction  : 400180 cycles (4.00 cycles/loop)
constant synthesis: 700000 cycles (7.00 cycles/loop)
L32R instruction  : 2000000 cycles (20.00 cycles/loop)

** adjacent 4 loading, 100000 times **
MOVI instruction  : 500179 cycles (5.00 cycles/loop)
constant synthesis: 900181 cycles (9.00 cycles/loop)
L32R instruction  : 2700180 cycles (27.00 cycles/loop)

** adjacent 5 loading, 100000 times **
MOVI instruction  : 600181 cycles (6.00 cycles/loop)
constant synthesis: 1100180 cycles (11.00 cycles/loop)
L32R instruction  : 3300000 cycles (33.00 cycles/loop)

** adjacent 6 loading, 100000 times **
MOVI instruction  : 700000 cycles (7.00 cycles/loop)
constant synthesis: 1300179 cycles (13.00 cycles/loop)
L32R instruction  : 4100180 cycles (41.00 cycles/loop)
```
(Arduino sketch is [here](https://github.com/earlephilhower/esp-quick-toolchain/files/7741040/constant_load_test.zip))

it concludes:
- MOVI instruction  : 1 cycle/load
- constant synthesis: 2 cycles/load
- L32R instruction  : 6 ~ 8 cycles/load

on ESP8266.

the refman says this behavior is implementation-specific: 
> This functionality (IRAM/IROM as data) is provided for initialization and test purposes, for which performance is not critical, so these operations may be significantly slower on some Xtensa implementations.

_Xtensa(R) Instruction Set Reference Manual, "4.5.8 General RAM/ROM Option Features"_