### PR TITLE
Add simple CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+on: [ push, pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc: [
+          # TODO: add other versions?
+          "10.3",
+        ]
+    steps:
+      - uses: actions/checkout@v3
+      - run: make GHUSER=earlephilhower GHTOKEN=unused GCC=${{ matrix.gcc }} download
+      - run: make GHUSER=earlephilhower GHTOKEN=unused GCC=${{ matrix.gcc }} -j$(nproc)


### PR DESCRIPTION
While doing this, I've encountered several issues.

1. https://github.com/earlephilhower/esp-quick-toolchain/issues/45
2. https://github.com/earlephilhower/esp-quick-toolchain/issues/46
3. Build log is hidden in `log.stage.%s` files, so if something breaks on CI, there is no way to figure out what went wrong. Possibly log redirection should either be removed completely or at least there should be a switch that disables redirection and normally writes everything to stdout/stderr.
4. `make download` needs to be given exactly the same build flags as later `make`. Otherwise, `git clone` is done again. This effectively means there is no point doing `make download` as a separate step, like README suggests.

----

You can see example CI run here: https://github.com/slonopotamus/esp-quick-toolchain/actions/runs/4398059816/jobs/7701630077